### PR TITLE
Fix voice-mode status fallback

### DIFF
--- a/app/api/voice-mode/status/route.ts
+++ b/app/api/voice-mode/status/route.ts
@@ -8,7 +8,14 @@ export async function GET() {
     const data = await fs.readFile(filePath, "utf-8")
     const json = JSON.parse(data)
     return NextResponse.json({ enabled: json.enabled })
-  } catch (e) {
-    return NextResponse.json({ error: "Erro ao ler status do modo de voz" }, { status: 500 })
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      // Arquivo não existe: considera modo de voz desativado por padrão
+      return NextResponse.json({ enabled: false })
+    }
+    return NextResponse.json(
+      { error: "Erro ao ler status do modo de voz" },
+      { status: 500 },
+    )
   }
-} 
+}


### PR DESCRIPTION
## Summary
- handle missing file in voice-mode status route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f51751a70832bad1e3fb29b1bf441