### PR TITLE
Implement caching and registration endpoint

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const { formData, cachedData } = body
+    const supabaseUrl = "https://znkfwlpgsxxawucacmda.supabase.co"
+    const supabaseKey = process.env.SUPABASE_KEY
+    if (!supabaseKey) {
+      return NextResponse.json({ error: "Supabase key não configurada" }, { status: 500 })
+    }
+    const supabase = createClient(supabaseUrl, supabaseKey as string)
+
+    const companyName = formData.companyName || cachedData?.companyName
+
+    if (!companyName) {
+      return NextResponse.json({ error: "Nome da empresa é obrigatório" }, { status: 400 })
+    }
+
+    // Atualiza o registro existente da empresa
+    const updateData: any = {
+      nome_cliente: formData.name || null,
+      email: formData.email || null,
+      telefone: formData.phone || null,
+      senha: formData.password || null,
+    }
+
+    if (cachedData?.analysis) {
+      updateData.diagnostico = cachedData.analysis
+    }
+    if (cachedData?.answers) {
+      cachedData.answers.forEach((ans: string, idx: number) => {
+        updateData[`resposta_${idx + 1}`] = ans || null
+      })
+    }
+
+    const { error } = await supabase
+      .from("brandplot")
+      .update(updateData)
+      .eq("nome_empresa", companyName)
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err: any) {
+    return NextResponse.json({ error: "Erro no registro" }, { status: 500 })
+  }
+}

--- a/components/brilho-original/brilho-original.tsx
+++ b/components/brilho-original/brilho-original.tsx
@@ -514,6 +514,16 @@ export default function BrilhoOriginal({
   // Get the company name from the first answer
   const companyName = answers[0] ? answers[0].trim() : "Sua Marca"
 
+  // Salva diagnóstico e respostas no cache do navegador
+  useEffect(() => {
+    if (analysis && currentStep === 12) {
+      const cacheData = { companyName, analysis, answers }
+      try {
+        localStorage.setItem("brandplotDraft", JSON.stringify(cacheData))
+      } catch {}
+    }
+  }, [analysis, answers, currentStep, companyName])
+
   const fadeUpVariants = {
     hidden: { opacity: 0, y: 30 },
     visible: (i: number) => ({

--- a/components/brilho-original/login-page.tsx
+++ b/components/brilho-original/login-page.tsx
@@ -146,8 +146,31 @@ export default function LoginPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Aqui você implementaria a lógica de login/cadastro
-    console.log(isLogin ? "Login" : "Cadastro", formData)
+    if (isLogin) {
+      console.log("Login", formData)
+      return
+    }
+
+    async function register() {
+      let cached: any = null
+      try {
+        const stored = localStorage.getItem("brandplotDraft")
+        if (stored) cached = JSON.parse(stored)
+      } catch {}
+
+      try {
+        const response = await fetch("/api/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ formData, cachedData: cached }),
+        })
+        console.log("Registro", await response.json())
+      } catch (err) {
+        console.error("Erro ao registrar", err)
+      }
+    }
+
+    register()
   }
 
   const toggleMode = () => {


### PR DESCRIPTION
## Summary
- store generated brand diagnosis in localStorage when results appear
- send stored data on registration form submit
- add API route to update record with registration details

## Testing
- `CI=1 npx next lint` *(fails: asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_683f538e0d08832bbf5500dcd44a5b18