### PR TITLE
Fix registration data not stored

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const { formData, cachedData } = body
+
+    const supabaseUrl = process.env.SUPABASE_URL ||
+      "https://znkfwlpgsxxawucacmda.supabase.co"
+    const supabaseKey = process.env.SUPABASE_KEY
+
+    if (!supabaseKey) {
+      console.error("Supabase key not configured")
+      return NextResponse.json(
+        { error: "Supabase key não configurada" },
+        { status: 500 }
+      )
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey as string)
+
+    const companyName = formData.companyName || cachedData?.companyName
+
+    if (!companyName) {
+      return NextResponse.json({ error: "Nome da empresa é obrigatório" }, { status: 400 })
+    }
+
+    // Atualiza o registro existente da empresa
+    const updateData: any = {
+      nome_cliente: formData.name || null,
+      email: formData.email || null,
+      telefone: formData.phone || null,
+      senha: formData.password || null,
+    }
+
+    if ((!updateData.email || !updateData.telefone) && cachedData?.answers) {
+      try {
+        const contact = JSON.parse(cachedData.answers[9] || "{}")
+        if (!updateData.email) updateData.email = contact.email || null
+        if (!updateData.telefone) updateData.telefone = contact.phone || null
+      } catch {
+        /* ignore parse errors */
+      }
+    }
+
+    if (cachedData?.analysis) {
+      updateData.diagnostico = cachedData.analysis
+    }
+    if (cachedData?.answers) {
+      cachedData.answers.forEach((ans: string, idx: number) => {
+        updateData[`resposta_${idx + 1}`] = ans || null
+      })
+    }
+
+    const { data: existing, error: selectError } = await supabase
+      .from("brandplot")
+      .select("id")
+      .eq("nome_empresa", companyName)
+      .maybeSingle()
+
+    if (selectError) {
+      console.error("Erro ao buscar registro:", selectError.message)
+      return NextResponse.json(
+        { error: "Erro ao verificar registro" },
+        { status: 500 }
+      )
+    }
+
+    let dbError
+
+    if (existing) {
+      const { error } = await supabase
+        .from("brandplot")
+        .update(updateData)
+        .eq("id", existing.id)
+
+      dbError = error
+    } else {
+      const insertData = { nome_empresa: companyName, ...updateData }
+      const { error } = await supabase.from("brandplot").insert(insertData)
+      dbError = error
+    }
+
+    if (dbError) {
+      console.error("Erro ao salvar registro:", dbError.message)
+      return NextResponse.json({ error: dbError.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err: any) {
+    return NextResponse.json({ error: "Erro no registro" }, { status: 500 })
+  }
+}

--- a/components/brilho-original/brilho-original.tsx
+++ b/components/brilho-original/brilho-original.tsx
@@ -514,6 +514,21 @@ export default function BrilhoOriginal({
   // Get the company name from the first answer
   const companyName = answers[0] ? answers[0].trim() : "Sua Marca"
 
+  // Salva diagnóstico e respostas no cache do navegador
+  useEffect(() => {
+    if (analysis && currentStep === 12) {
+      const cacheData = { companyName, analysis, answers }
+      if (answers[9]) {
+        cacheData.contact = answers[9]
+      }
+      try {
+        localStorage.setItem("brandplotDraft", JSON.stringify(cacheData))
+      } catch {
+        /* noop */
+      }
+    }
+  }, [analysis, answers, currentStep, companyName])
+
   const fadeUpVariants = {
     hidden: { opacity: 0, y: 30 },
     visible: (i: number) => ({

--- a/components/brilho-original/login-page.tsx
+++ b/components/brilho-original/login-page.tsx
@@ -121,6 +121,24 @@ export default function LoginPage() {
           }))
         }
       }
+
+      if (!company && !contact) {
+        try {
+          const stored = localStorage.getItem('brandplotDraft')
+          if (stored) {
+            const cached = JSON.parse(stored)
+            const contactInfo = cached.contact
+              ? JSON.parse(cached.contact)
+              : {}
+            setFormData(prev => ({
+              ...prev,
+              companyName: cached.companyName || prev.companyName,
+              email: contactInfo.email || prev.email,
+              phone: contactInfo.phone || prev.phone,
+            }))
+          }
+        } catch {}
+      }
     }
   }, [])
 
@@ -146,8 +164,35 @@ export default function LoginPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Aqui você implementaria a lógica de login/cadastro
-    console.log(isLogin ? "Login" : "Cadastro", formData)
+    if (isLogin) {
+      console.log("Login", formData)
+      return
+    }
+
+    async function register() {
+      let cached: any = null
+      try {
+        const stored = localStorage.getItem("brandplotDraft")
+        if (stored) cached = JSON.parse(stored)
+      } catch {}
+
+      try {
+        const response = await fetch("/api/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ formData, cachedData: cached }),
+        })
+        const result = await response.json()
+        console.log("Registro", result)
+        if (response.ok) {
+          router.push("/dashboard")
+        }
+      } catch (err) {
+        console.error("Erro ao registrar", err)
+      }
+    }
+
+    register()
   }
 
   const toggleMode = () => {


### PR DESCRIPTION
## Summary
- handle missing company record when registering
- keep cached contact info from the questionnaire
- pre-fill registration form from cached data
- redirect to dashboard after successful registration

## Testing
- `CI=1 npx next lint` *(fails: missing TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f538e0d08832bbf5500dcd44a5b18